### PR TITLE
Fix image path for Training Convergence Graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         }
         
         nav a:hover {
-            background-color: var(--royal-gold);
+            background-color: var (--royal-gold);
             color: var(--oxford-blue);
         }
         
@@ -367,7 +367,7 @@
             <p>The experimental findings demonstrate exceptional performance characteristics of the CMA-ES agent. The training process exhibited rapid convergence properties, with the agent achieving optimal policy parameters within remarkably few iterations.</p>
             
             <div class="results-graph">
-                <img src="/plots/training_convergence.png" alt="Training Convergence Graph" class="responsive-img" />
+                <img src="assets/training_convergence.png" alt="Training Convergence Graph" class="responsive-img" />
                 <p><em>Figure 1: Training convergence showing the mean fitness (episode length) across generations. The model achieves optimal performance (500 steps) within 5 iterations.</em></p>
             </div>
             


### PR DESCRIPTION
Update the image source path for the Training Convergence Graph image in `index.html`.

* Change the image source path from `/plots/training_convergence.png` to `assets/training_convergence.png` in the `img` tag.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bniladridas/cmaes-rl/pull/1?shareId=83e41911-330a-4939-bb02-80b6af5ab759).